### PR TITLE
Added Read Flag

### DIFF
--- a/src/Accessory.cpp
+++ b/src/Accessory.cpp
@@ -256,12 +256,12 @@ void Accessory::begin() {
 
 }
 
-void Accessory::_burstRead() {
-    _burstReadWithAddress(0);
+boolean Accessory::_burstRead() {
+    return _burstReadWithAddress(0);
 }
 
 
-void Accessory::_burstReadWithAddress(uint8_t addr) {
+boolean Accessory::_burstReadWithAddress(uint8_t addr) {
     int readAmnt = sizeof(_dataarray);
 
     // send conversion command
@@ -280,6 +280,8 @@ void Accessory::_burstReadWithAddress(uint8_t addr) {
     if(_encrypted) {
         for (int i=0; i<sizeof(_dataarray); i++) _dataarray[i] = decryptByte(_dataarray[i],addr+i);
     }
+    
+    return readBytes == sizeof(_dataarray);
     
     //Serial.print("R ");//Serial.print(addr,HEX);
     //Serial.print(" (");//Serial.print(readAmnt);

--- a/src/Accessory.cpp
+++ b/src/Accessory.cpp
@@ -88,10 +88,11 @@ ControllerType Accessory::identifyController() {
  * public function to read data
  */
 boolean Accessory::readData() {
-    boolean successFlag = _burstRead();
-    _applyMaps();
-    
-    return successFlag;
+    if(_burstRead()){
+        _applyMaps();
+        return true;
+    }
+    return false;
 }
 
 uint8_t* Accessory::getDataArray() {

--- a/src/Accessory.cpp
+++ b/src/Accessory.cpp
@@ -87,10 +87,11 @@ ControllerType Accessory::identifyController() {
 /*
  * public function to read data
  */
-void Accessory::readData() {
-
-    _burstRead();
+boolean Accessory::readData() {
+    boolean successFlag = _burstRead();
     _applyMaps();
+    
+    return successFlag;
 }
 
 uint8_t* Accessory::getDataArray() {

--- a/src/Accessory.cpp
+++ b/src/Accessory.cpp
@@ -273,8 +273,8 @@ void Accessory::_burstReadWithAddress(uint8_t addr) {
     delay(1);
 
     // read data
-    myWire.readBytes(_dataarray,
-                     myWire.requestFrom(I2C_ADDR, sizeof(_dataarray)));
+    uint8_t readBytes = myWire.readBytes(_dataarray,
+                          myWire.requestFrom(I2C_ADDR, sizeof(_dataarray)));
 
     
     if(_encrypted) {

--- a/src/Accessory.h
+++ b/src/Accessory.h
@@ -53,7 +53,7 @@ public:
     void printInputs(Stream& stream);
 
     void begin();
-    void readData();
+    boolean readData();
 
     void enableEncryption(bool enc);
 

--- a/src/Accessory.h
+++ b/src/Accessory.h
@@ -125,8 +125,8 @@ protected:
 
     ControllerType identifyController();
     Mapping* firstMap;
-    void _burstRead();
-    void _burstReadWithAddress(uint8_t addr);
+    boolean _burstRead();
+    boolean _burstReadWithAddress(uint8_t addr);
     void _writeRegister(uint8_t reg, uint8_t value);
     void _burstWriteWithAddress(uint8_t addr,uint8_t* arr,uint8_t size);
 


### PR DESCRIPTION
I changed the `readData();` function and its dependencies to return a boolean value if a data read was successful (# of bytes requested = # of bytes received). This allows a user to ignore input values if the controller gets disconnected.

After giving it some more thought, I also changed this to not apply new servo maps if the data was not read successfully.